### PR TITLE
Update init.rk30board.rc

### DIFF
--- a/init.rk30board.rc
+++ b/init.rk30board.rc
@@ -171,11 +171,6 @@ service iprenew_bt-pan /system/bin/dhcpcd -n
     disabled
     oneshot
     
-service usb_modeswitch /system/bin/usb_modeswitch -I -W -c /etc/usb_modeswitch.conf
-     class main
-     disabled
-     oneshot
-
 on property:ro.boot.charger.emmc=1
     mount ext4 /dev/block/platform/emmc/by-name/system /system wait ro noatime nodiratime
     start console


### PR DESCRIPTION
Remove the usb_modeswitch service define.   It wrong and not needed since the G3Dev code handles the launching and loading of the device proper config.   At fist I did not realize that, so the code was added.  My mistake.
